### PR TITLE
feat(mock_server): Added Restful mock server for testing

### DIFF
--- a/tests/mock_messages/README.md
+++ b/tests/mock_messages/README.md
@@ -1,6 +1,6 @@
 # Mock Messages
 
-Used for sending mock messages for testing
+Used for mock HTTP Restful server as well as sending mock messages to PubNub for testing.
 
 ## Installation
 
@@ -30,6 +30,9 @@ You can get those keys from your PubNub account and use the below command to enc
 python -c "from crypto import encrypt; print(encrypt('My secret key'))"
 ```
 
+Note: this is only for a our mock server. In production we'll recommend that you encrypt it using AWS KMS,
+Vault or other services where there are key rotation and other more advanced security.
+
 
 ## Running
 
@@ -42,5 +45,36 @@ source .env
 They run the script below
 
 ```
-python send_messages.py
+python mock_server.py
 ```
+
+To get the initial state. This represent the current state of the screen used when the UI first initialises. 
+
+```
+curl http://127.0.0.1:8765/initial_state 
+```
+
+Example output: 
+
+```
+[{"event_id":"event-1","name":"Jack Sparrow","icon":"person_check","icon_type":"material","reward":""},{"event_id":"event-1","name":"Will Turner","icon":"person_check","icon_type":"material","reward":""}] 
+```
+
+As we can see above, check ins are associated with events. The UI can request information about the event.
+
+```
+curl "http://127.0.0.1:8765/event?event_id=event-1"
+```
+
+Example output:
+
+```
+{"id":"event-1","title":"BJJ","description":"BJJ Fundamentals","start_time":"18:00","end_time":"19:30","icon":"bjj","icon_type":"internal"} 
+```
+
+On top of the Restful service the mocker server provides, it also pumps out messages to PubNub.
+
+The below are example outputs in the terminal of messages being publishes on intervals.
+
+The ``initial_state`` request will include additional check ins if the UI requests for it
+(i.e. refreshing the webpage).

--- a/tests/mock_messages/mock_fixture1.json
+++ b/tests/mock_messages/mock_fixture1.json
@@ -1,44 +1,96 @@
-[
-    {
-        "name": "John Smith",
-        "icon": "person_check",
-        "icon_type": "material",
-        "reward": "⭐"
+{
+    "settings": {
+        "theme": "default",
+        "display_mode": "dark"
     },
-    {
-        "name": "Peter Parker",
-        "icon": "person_check",
-        "icon_type": "material",
-        "reward": ""
+    "events": {
+        "event-1": {
+            "id": "event-1",
+            "title": "BJJ",
+            "description": "BJJ Fundamentals",
+            "start_time": "18:00",
+            "end_time": "19:30",
+            "icon": "bjj",
+            "icon_type": "internal"
+        },
+        "event-2": {
+            "id": "event-2",
+            "title": "Muay Thai",
+            "description": "Muay Thai",
+            "start_time": "19:30",
+            "end_time": "21:00",
+            "icon": "muay_thai",
+            "icon_type": "internal"
+        }
     },
-    {
-        "name": "Uzumaki Naruto",
-        "icon": "person",
-        "icon_type": "material",
-        "reward": ""
+    "initial_state": [
+        {
+            "event_id": "event-1",
+            "name": "Jack Sparrow",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": ""
+        },
+        {
+            "event_id": "event-1",
+            "name": "Will Turner",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": ""
+        }
+    ],
+    "message_settings": {
+        "interval": 5
     },
-    {
-        "name": "Midoriya Izuku",
-        "icon": "person_check",
-        "icon_type": "material",
-        "reward": "⭐⭐⭐"
-    },
-    {
-        "name": "Bob Marley",
-        "icon": "person_check",
-        "icon_type": "material",
-        "reward": ""
-    },
-    {
-        "name": "Roger Gracie",
-        "icon": "person_check",
-        "icon_type": "material",
-        "reward": "🥋"
-    },
-    {
-        "name": "Sombat Banchamek",
-        "icon": "person_check",
-        "icon_type": "material",
-        "reward": "🥊"
-    }
-]
+    "messages": [
+        {
+            "event_id": "event-1",
+            "name": "John Smith",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": "⭐"
+        },
+        {
+            "event_id": "event-1",
+            "name": "Peter Parker",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": ""
+        },
+        {
+            "event_id": "event-1",
+            "name": "Uzumaki Naruto",
+            "icon": "person",
+            "icon_type": "material",
+            "reward": ""
+        },
+        {
+            "event_id": "event-1",
+            "name": "Midoriya Izuku",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": "⭐⭐⭐"
+        },
+        {
+            "event_id": "event-1",
+            "name": "Bob Marley",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": ""
+        },
+        {
+            "event_id": "event-1",
+            "name": "Roger Gracie",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": "🥋"
+        },
+        {
+            "event_id": "event-2",
+            "name": "Sombat Banchamek",
+            "icon": "person_check",
+            "icon_type": "material",
+            "reward": "🥊"
+        }
+    ]
+}

--- a/tests/mock_messages/mock_server.py
+++ b/tests/mock_messages/mock_server.py
@@ -1,0 +1,44 @@
+from email import message
+from pubnub.pnconfiguration import PNConfiguration
+from pubnub.pubnub import PubNub
+from fastapi import FastAPI
+import uvicorn
+from typing import Optional
+import json
+from crypto import get_secret
+from send_messages import MockSubscribeCallback
+
+app = FastAPI()
+
+fixture: Optional[dict] = None
+message_history = []
+
+
+@app.get("/event")
+def event(event_id: str):
+    return fixture['events'][event_id]
+
+@app.get("/initial_state")
+def initial_state():
+    return fixture['initial_state'] + message_history
+
+
+if __name__ == "__main__":
+    fixture_name = "mock_fixture1"
+
+    with open(fixture_name + ".json", "r") as f:
+        fixture = json.load(f)
+
+    pnconfig = PNConfiguration()
+
+    pnconfig.subscribe_key = get_secret('PUB_NUB_SUBSCRIBE_KEY')
+    pnconfig.publish_key = get_secret('PUB_NUB_PUBLISH_KEY')
+    pnconfig.user_id = "my_custom_user_id"
+
+    pubnub = PubNub(pnconfig)
+
+    mock_sub = MockSubscribeCallback(fixture=fixture, message_history=message_history)
+    pubnub.add_listener(mock_sub)
+    pubnub.subscribe().channels('dev-checkin').execute()
+
+    uvicorn.run(app, host="0.0.0.0", port=8765)

--- a/tests/mock_messages/requirements.txt
+++ b/tests/mock_messages/requirements.txt
@@ -1,2 +1,4 @@
 pubnub
 cryptography
+uvicorn
+fastapi

--- a/tests/mock_messages/send_messages.py
+++ b/tests/mock_messages/send_messages.py
@@ -1,12 +1,8 @@
 from pubnub.callbacks import SubscribeCallback
 from pubnub.enums import PNStatusCategory
-from pubnub.pnconfiguration import PNConfiguration
-from pubnub.pubnub import PubNub
 from threading import Thread
 from typing import Optional
 from time import sleep
-import json
-from crypto import get_secret
 
 
 def mock_publish_callback(envelope, status):
@@ -17,13 +13,12 @@ def mock_publish_callback(envelope, status):
 
 class MockSubscribeCallback(SubscribeCallback):
     def __init__(self, *args, **kwargs):
-        fixture_name = kwargs.pop("fixture_name")
-        interval = kwargs.pop("interval")
+        self.fixture = kwargs.pop("fixture")
+        self.message_history = kwargs.pop("message_history")
+
         super().__init__(*args, **kwargs)
         self.publish_thread: Optional[Thread] = None
-        with open(fixture_name + ".json", "r") as f:
-            self.fixture = json.load(f)
-        self.interval = interval
+        self.interval = self.fixture['message_settings']['interval']
 
         self.pubnub = None
 
@@ -49,23 +44,10 @@ class MockSubscribeCallback(SubscribeCallback):
     def message(self, pubnub, message):
         # Handle new message stored in message.message
         print(f"Received message: {message.message}")
+        self.message_history.append(message.message)
 
     def publish_loop(self):
-        for member in self.fixture:
+        for member in self.fixture['messages']:
             self.pubnub.publish().channel(
                 'dev-checkin').message(member).pn_async(mock_publish_callback)
             sleep(self.interval)
-
-
-if __name__ == '__main__':
-    pnconfig = PNConfiguration()
-
-    pnconfig.subscribe_key = get_secret('PUB_NUB_SUBSCRIBE_KEY')
-    pnconfig.publish_key = get_secret('PUB_NUB_PUBLISH_KEY')
-    pnconfig.user_id = "my_custom_user_id"
-
-    pubnub = PubNub(pnconfig)
-
-    mock_sub = MockSubscribeCallback(fixture_name='mock_fixture1', interval=5)
-    pubnub.add_listener(mock_sub)
-    pubnub.subscribe().channels('dev-checkin').execute()


### PR DESCRIPTION
Added a mock restful server to query for event information and initial state.
Fixed issue with publishing messages on python 3.12

Instead of running send_messages.py, run mock_server.py
For more information please read the README